### PR TITLE
docs: fix broken link in docs to metroline_job_docker_sock

### DIFF
--- a/src/data/docs/40-guides/10-building-docker-images-inside-jobs.md
+++ b/src/data/docs/40-guides/10-building-docker-images-inside-jobs.md
@@ -38,7 +38,7 @@ command exited with code 1
 
 </div>
 
-This problem occurs because your job doesn't have a Docker socket at hand. To provide it with one, restart your runner with the [METROLINE_JOB_DOCKER_SOCK](/docs/environment-reference/runner#metroline_job_docker_sock) environment variable set:
+This problem occurs because your job doesn't have a Docker socket at hand. To provide it with one, restart your runner with the [METROLINE\_JOB\_DOCKER\_SOCK](/docs/runner-environment-reference#metroline_job_docker_sock) environment variable set:
 
 <div class="blockquote" data-props='{ "mod": "danger" }'>
 


### PR DESCRIPTION
fixes:
 - markdown formatting issue
 - broken link

currently looks like this markdown is rendered.
![image](https://user-images.githubusercontent.com/60991921/97513466-23568580-196b-11eb-9826-839d5ec48638.png)

and links to https://docs.metroline.io/docs/environment-reference/runner#metroline_job_docker_sock when it should link to https://docs.metroline.io/environment-reference/runner-environment-reference#metroline_job_docker_sock.